### PR TITLE
Disable upload button while predicting

### DIFF
--- a/static/js/webapp.js
+++ b/static/js/webapp.js
@@ -160,6 +160,7 @@ $(function() {
 
     if ($('#file-input').val() !== '') {
       $('#file-submit').text('Detecting...');
+      $('#file-submit').prop('disabled', true);
 
       // Perform file upload
       $.ajax({
@@ -181,6 +182,7 @@ $(function() {
         },
         complete: function() {
           $('#file-submit').text('Submit');
+          $('#file-submit').prop('disabled', false);
           $('#file-input').val('');
         },
       });


### PR DESCRIPTION
Currently if you try uploading an image while one is already processing it will display the new image but use the canvas for the first image.