### PR TITLE
Add error handling to model requests

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,7 +30,12 @@ var app = express();
 app.use(express.static('static'));
 
 app.all('/model/:route', function(req, res) {
-  req.pipe(request(args.model + req.path)).pipe(res);
+  req.pipe(request(args.model + req.path))
+  .on('error', err => {
+    console.error(err);
+    res.status(500).send('Error connecting to the model microservice');
+  })
+  .pipe(res);
 });
 
 app.listen(args.port);

--- a/app.js
+++ b/app.js
@@ -31,11 +31,11 @@ app.use(express.static('static'));
 
 app.all('/model/:route', function(req, res) {
   req.pipe(request(args.model + req.path))
-  .on('error', err => {
-    console.error(err);
-    res.status(500).send('Error connecting to the model microservice');
-  })
-  .pipe(res);
+    .on('error', function(err) {
+      console.error(err);
+      res.status(500).send('Error connecting to the model microservice');
+    })
+    .pipe(res);
 });
 
 app.listen(args.port);

--- a/static/js/webapp.js
+++ b/static/js/webapp.js
@@ -178,7 +178,7 @@ $(function() {
           }
         },
         error: function(jqXHR, status, error) {
-          alert('Object Detection Failed: ' + error);
+          alert('Object Detection Failed: ' + jqXHR.responseText);
         },
         complete: function() {
           $('#file-submit').text('Submit');


### PR DESCRIPTION
As found in #17 the error thrown when the model microservice is unreachable is unreadable and should be handled

Now instead of erroring confusingly then dying the error is posted on the console and the user is given a message to check thier microservice

This also does not kill the web app since the microservice can be started while the app is running and the app will then use it